### PR TITLE
Add support for spaces in adb path

### DIFF
--- a/src/android/adb.ts
+++ b/src/android/adb.ts
@@ -1,31 +1,31 @@
-import { spawn, execSync, ChildProcess } from 'child_process';
-import path from 'path';
+import { spawn, execSync, ChildProcess } from "child_process";
+import path from "path";
 import {
   CodeError,
   ERR_ANDROID_UNPROCESSABLE_PID,
   ERR_ANDROID_CANNOT_GET_APP_PID,
   ERR_ANDROID_CANNOT_CLEAN_LOGCAT_BUFFER,
-  ERR_ANDROID_CANNOT_START_LOGCAT,
-} from '../errors';
+  ERR_ANDROID_CANNOT_START_LOGCAT
+} from "../errors";
 
 export function runAndroidLoggingProcess(adbPath?: string): ChildProcess {
-  const execPath = getAbdPath(adbPath);
+  const execPath = getAdbPath(adbPath);
   return spawnLogcatProcess(execPath);
 }
 
-export function getAbdPath(customPath?: string): string {
+export function getAdbPath(customPath?: string): string {
   if (customPath) {
     return path.resolve(customPath);
   }
 
   return process.env.ANDROID_HOME
     ? `${process.env.ANDROID_HOME}/platform-tools/adb`
-    : 'adb';
+    : "adb";
 }
 
 export function spawnLogcatProcess(adbPath: string): ChildProcess {
   try {
-    execSync(`${adbPath} logcat -c`);
+    execSync(`"${adbPath}" logcat -c`);
   } catch (error) {
     throw new CodeError(
       ERR_ANDROID_CANNOT_CLEAN_LOGCAT_BUFFER,
@@ -34,8 +34,8 @@ export function spawnLogcatProcess(adbPath: string): ChildProcess {
   }
 
   try {
-    return spawn(adbPath, ['logcat', '-v', 'time', 'process', 'tag'], {
-      stdio: 'pipe',
+    return spawn(adbPath, ["logcat", "-v", "time", "process", "tag"], {
+      stdio: "pipe"
     });
   } catch (error) {
     throw new CodeError(
@@ -51,7 +51,9 @@ export function getApplicationPid(
 ): number {
   let output: Buffer | undefined;
   try {
-    output = execSync(`${getAbdPath(adbPath)} shell pidof -s ${applicationId}`);
+    output = execSync(
+      `"${getAdbPath(adbPath)}" shell pidof -s ${applicationId}`
+    );
   } catch (error) {
     throw new CodeError(
       ERR_ANDROID_CANNOT_GET_APP_PID,

--- a/src/android/adb.ts
+++ b/src/android/adb.ts
@@ -1,12 +1,12 @@
-import { spawn, execSync, ChildProcess } from "child_process";
-import path from "path";
+import { spawn, execSync, ChildProcess } from 'child_process';
+import path from 'path';
 import {
   CodeError,
   ERR_ANDROID_UNPROCESSABLE_PID,
   ERR_ANDROID_CANNOT_GET_APP_PID,
   ERR_ANDROID_CANNOT_CLEAN_LOGCAT_BUFFER,
   ERR_ANDROID_CANNOT_START_LOGCAT
-} from "../errors";
+} from '../errors';
 
 export function runAndroidLoggingProcess(adbPath?: string): ChildProcess {
   const execPath = getAdbPath(adbPath);
@@ -20,12 +20,12 @@ export function getAdbPath(customPath?: string): string {
 
   return process.env.ANDROID_HOME
     ? `${process.env.ANDROID_HOME}/platform-tools/adb`
-    : "adb";
+    : 'adb';
 }
 
 export function spawnLogcatProcess(adbPath: string): ChildProcess {
   try {
-    execSync(`"${adbPath}" logcat -c`);
+    execSync(`'${adbPath}' logcat -c`);
   } catch (error) {
     throw new CodeError(
       ERR_ANDROID_CANNOT_CLEAN_LOGCAT_BUFFER,
@@ -34,8 +34,8 @@ export function spawnLogcatProcess(adbPath: string): ChildProcess {
   }
 
   try {
-    return spawn(adbPath, ["logcat", "-v", "time", "process", "tag"], {
-      stdio: "pipe"
+    return spawn(adbPath, ['logcat', '-v', 'time', 'process', 'tag'], {
+      stdio: 'pipe'
     });
   } catch (error) {
     throw new CodeError(


### PR DESCRIPTION
My `adb` executable is located inside "Program Files (x86)" and `logkitty` fails to get it. Add quotations around the adb path seems to fix it.