### PR TITLE
Implement custom path to adb

### DIFF
--- a/docs/NODE_API.md
+++ b/docs/NODE_API.md
@@ -34,7 +34,7 @@ emitter.on('error', (error: Error) => {
 Spawns logkitty with given options:
 
 * `platform: 'android' | 'ios'` - Platform to get the logs from: uses `adb logcat` for Android and `xcrun simctl` + `log` for iOS simulator`.
-* `adbPath?: string` - Custom path to ADB tool or `undefined` (used only when `platform` is `android`).
+* `adbPath?: string` - Custom path to adb tool or `undefined` (used only when `platform` is `android`).
 * `priority?: number` - Minimum priority of entries to show of `undefined`, which will include all entries with priority **DEBUG** (Android)/**DEFAULT** (iOS) or above.
 * `filter?: FilterCreator` - The returned value from `makeTagsFilter`/`makeAppFilter`/`makeMatchFilter`/`makeCustomFilter` or `undefined`, which will include all entries (similar to `all` command in the CLI).
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -118,7 +118,8 @@ const {
       .demandCommand(1)
       .option('adb-path', {
         type: 'string',
-        describe: 'Use custom path to ADB',
+        describe: 'Use custom path to adb',
+        nargs: 1,
       })
       .example(
         '$0 android tag MyTag',
@@ -145,7 +146,7 @@ const {
         'Silence all logs and show only ones with MyTag with priority DEBUG and above'
       )
   )
-  .command('ios <filter>', 'ios', yargs =>
+  .command('ios <filter>', 'iOS', yargs =>
     yargs
       .command(
         'tag <tags ...>',
@@ -216,6 +217,7 @@ try {
   }
   const emitter = logkitty({
     platform: platform as Platform,
+    adbPath: args.adbPath ? String(args.adbPath) : '',
     priority:
       platform === 'android'
         ? getMinPriority(


### PR DESCRIPTION
Support for `--adb-path` was already mentioned in `logkitty`'s help text:

```
Options:
  -h, --help     Show help                                             [boolean]
  --adb-path     Use custom path to ADB                                 [string]
  -v, --version  Show version number                                   [boolean]
```

It was _mostly_ implemented in source code as well, however due to an important line missing it was not functional.

```sh
logkitty android --adb-path ~/tmp/adb all
```

Previously, the value of `adb-path` was just ignored, and it would use `adb` from `$ANDROID_HOME`. With this change it is using the path as specified.

Also lower-cased adb (which is the spelling used in `adb`'s output as well).