### PR TITLE
[Security Patch] bump yargs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "ansi-fragments": "^0.2.1",
     "dayjs": "^1.8.22",
-    "yargs": "^15.3.0"
+    "yargs": "^15.3.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
`yargs-aprser` and by extension `yargs` was affected by [this](https://www.npmjs.com/advisories/1500) vulnerability.

I ran into this from React Native, after running `yarn-audit`
![image](https://user-images.githubusercontent.com/13405567/81362502-01accd80-90af-11ea-95de-18ba589b5fbf.png)

Thanks!